### PR TITLE
Fix emission of outer name in InnerClass entries

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -163,7 +163,7 @@ class BTypesFromSymbols[I <: BackendInterface](val int: I) extends BTypes {
         } else {
           val outerName = innerClassSym.rawowner.javaBinaryName
           // Java compatibility. See the big comment in BTypes that summarizes the InnerClass spec.
-          val outerNameModule = if (innerClassSym.isTopLevelModuleClass) outerName.dropModule
+          val outerNameModule = if (innerClassSym.rawowner.isTopLevelModuleClass) outerName.dropModule
           else outerName
           Some(outerNameModule.toString)
         }


### PR DESCRIPTION
Commit 3d66b0dc contains the following change:
```diff
-          val outerNameModule = if (isTopLevelModuleClass(innerClassSym.rawowner)) outerName.dropModule
+          val outerNameModule = if (innerClassSym.isTopLevelModuleClass) outerName.dropModule
```

It looks like the `.rawowner` got accidentally dropped. The result is
that for the given code:
```scala
object Outer {
  class Inner
}
```
The ClassEntry for Inner has outer name "Outer$" instead of "Outer",
this prevents referencing "Outer.Inner" from Java code.