### PR TITLE
avoid using macro-based StringContext.f to ease bootstrap

### DIFF
--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -158,7 +158,7 @@ private[scala] trait PropertiesTrait {
   def jdkHome               = envOrElse("JDK_HOME", envOrElse("JAVA_HOME", javaHome))
 
   // private[scala] for 2.12
-  private[this] def versionFor(command: String) = f"Scala $command $versionString -- $copyrightString"
+  private[this] def versionFor(command: String) = s"Scala $command $versionString -- $copyrightString"
 
   def versionMsg            = versionFor(propCategory)
   def scalaCmd              = if (isWin) "scala.bat" else "scala"


### PR DESCRIPTION
I think `s` suffices here, no need for the macro-based `f`. Review @DarkDimius .