### PR TITLE
Minor stdlib changes needed for the tuple PR

### DIFF
--- a/src/library/scala/collection/mutable/ArrayOps.scala
+++ b/src/library/scala/collection/mutable/ArrayOps.scala
@@ -129,8 +129,8 @@ trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParalleliza
     var i = 0
     while (i < length) {
       val e = apply(i)
-      a1(i) = e._1
-      a2(i) = e._2
+      a1(i) = asPair(e)._1
+      a2(i) = asPair(e)._2
       i += 1
     }
     (a1, a2)
@@ -162,9 +162,9 @@ trait ArrayOps[T] extends Any with ArrayLike[T, Array[T]] with CustomParalleliza
     var i = 0
     while (i < length) {
       val e = apply(i)
-      a1(i) = e._1
-      a2(i) = e._2
-      a3(i) = e._3
+      a1(i) = asTriple(e)._1
+      a2(i) = asTriple(e)._2
+      a3(i) = asTriple(e)._3
       i += 1
     }
     (a1, a2, a3)

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -395,7 +395,7 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5]): Ordering[(T1, T2, T3, T4, T5)] =
     new Ordering[(T1, T2, T3, T4, T5)]{
-      def compare(x: (T1, T2, T3, T4, T5), y: Tuple5[T1, T2, T3, T4, T5]): Int = {
+      def compare(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Int = {
         val compare1 = ord1.compare(x._1, y._1)
         if (compare1 != 0) return compare1
         val compare2 = ord2.compare(x._2, y._2)


### PR DESCRIPTION
- scala/collection/mutable/ArrayOps.scala

Because `_i` are added via implicit conversion, these lines now need to trigger two implicit conversions in a raw, which is not supported by scalac.

- scala/math/Ordering.scala

Somehow for the second argument of the `Tuple5` does not uses the (...) syntax. Because of the scala package it references `scala.Tuple5`, which means the method is not a proper override for def compare.