### PR TITLE
SD-233 synchronized blocks are JIT-friendly again

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -72,9 +72,11 @@ trait BCodeSyncAndTry extends BCodeBodyBuilder {
       /* ------ (4) exception-handler version of monitor-exit code.
        *            Reached upon abrupt termination of (2).
        *            Protected by whatever protects the whole synchronized expression.
+       *            null => "any" exception in bytecode, like we emit for finally.
+       *            Important not to use j/l/Throwable which dooms the method to a life of interpretation! (SD-233)
        * ------
        */
-      protect(startProtected, endProtected, currProgramPoint(), ThrowableReference)
+      protect(startProtected, endProtected, currProgramPoint(), null)
       locals.load(monitor)
       emit(asm.Opcodes.MONITOREXIT)
       emit(asm.Opcodes.ATHROW)


### PR DESCRIPTION
This commit is adapted from e994c1c0becddc0d91fd4428f0d673bfac8941a3 in
scalac by Jason Zaugg, without the extra bytecode tests since the
BytecodeTests.scala file does not exist in our branch:

GenBCode, the new backend in Scala 2.12, subtly changed
the way that synchronized blocks are emitted.

It used `java/lang/Throwable` as an explicitly named exception
type, rather than implying the same by omitting this in bytecode.

This appears to confuse HotSpot JIT, which reports a error
parsing the bytecode into its IR which leaves the enclosing method
stuck in interpreted mode.

This commit passes a `null` descriptor to restore the old pattern
(the same one used by javac.) I've checked that the JIT warnings
are gone and that the method can be compiled again.