### PR TITLE
Abstract away all the things

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeAsmCommon.scala
@@ -5,8 +5,6 @@
 
 package scala.tools.nsc.backend.jvm
 
-import scala.reflect.internal.AnnotationInfos
-
 /**
  * This trait contains code shared between GenBCode and GenASM that depends on types defined in
  * the compiler cake (Global).
@@ -112,9 +110,8 @@ object BCodeAsmCommon{
     ca
   }
 
-  final def arrEncode(sb: AnnotationInfos#ScalaSigBytes): Array[String] = {
+  final def arrEncode(bSeven: Array[Byte]): Array[String] = {
     var strs: List[String]  = Nil
-    val bSeven: Array[Byte] = sb.sevenBitsMayBeZero
     // chop into slices of at most 65535 bytes, counting 0x00 as taking two bytes (as per JVMS 4.4.7 The CONSTANT_Utf8_info Structure)
     var prevOffset = 0
     var offset     = 0
@@ -142,12 +139,13 @@ object BCodeAsmCommon{
   }
 
 
-  def strEncode(sb: AnnotationInfos#ScalaSigBytes): String = {
-    val ca = ubytesToCharArray(sb.sevenBitsMayBeZero)
+  def strEncode(bSeven: Array[Byte]): String = {
+    val ca = ubytesToCharArray(bSeven)
     new java.lang.String(ca)
     // debug val bvA = new asm.ByteVector; bvA.putUTF8(s)
     // debug val enc: Array[Byte] = scala.reflect.internal.pickling.ByteCodecs.encode(bytes)
     // debug assert(enc(idx) == bvA.getByte(idx + 2))
     // debug assert(bvA.getLength == enc.size + 2)
   }
+
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc.backend.jvm
 
 import scala.collection.generic.Clearable
 import scala.reflect.ClassTag
-import scala.reflect.io.AbstractFile
+import scala.tools.nsc.io.AbstractFile
 import scala.language.implicitConversions
 import scala.tools.asm
 
@@ -633,7 +633,7 @@ abstract class BackendInterface extends BackendInterfaceDefinitions {
     def newWeakMap[K, V](): collection.mutable.WeakHashMap[K, V]
     def newMap[K, V](): collection.mutable.HashMap[K, V]
     def newSet[K](): collection.mutable.Set[K]
-    def newWeakSet[K <: AnyRef](): reflect.internal.util.WeakHashSet[K]
+    def newWeakSet[K >: Null <: AnyRef](): reflect.internal.util.WeakHashSet[K]
     def newAnyRefMap[K <: AnyRef, V](): collection.mutable.AnyRefMap[K, V]
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -899,10 +899,10 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
           // see http://www.scala-lang.org/sid/10 (Storage of pickled Scala signatures in class files)
           // also JVMS Sec. 4.7.16.1 The element_value structure and JVMS Sec. 4.4.7 The CONSTANT_Utf8_info Structure.
           if (sb.fitsInOneString)
-            av.visit(name, strEncode(sb))
+            av.visit(name, strEncode(sb.sevenBitsMayBeZero))
           else {
             val arrAnnotV: asm.AnnotationVisitor = av.visitArray(name)
-            for(arg <- arrEncode(sb)) { arrAnnotV.visit(name, arg) }
+            for(arg <- arrEncode(sb.sevenBitsMayBeZero)) { arrAnnotV.visit(name, arg) }
             arrAnnotV.visitEnd()
           }
           // for the lazy val in ScalaSigBytes to be GC'ed, the invoker of emitAnnotations() should hold the ScalaSigBytes in a method-local var that doesn't escape.

--- a/src/compiler/scala/tools/nsc/backend/jvm/ScalacBackendInterface.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ScalacBackendInterface.scala
@@ -10,7 +10,6 @@ import scala.reflect.io.AbstractFile
 import scala.language.implicitConversions
 import scala.reflect.internal.{Flags => IFlags}
 
-
 /* Uses pre-allocated objects to not allocate objects during pattern matching and during implicit conversion.
  * Due to this every instance in not threadsafe, but multiple instances could be used in parrallel if underlying compiler
  * supports this
@@ -1025,10 +1024,10 @@ class ScalacBackendInterface[G <: Global](val global: G) extends BackendInterfac
         // see http://www.scala-lang.org/sid/10 (Storage of pickled Scala signatures in class files)
         // also JVMS Sec. 4.7.16.1 The element_value structure and JVMS Sec. 4.4.7 The CONSTANT_Utf8_info Structure.
         if (sb.fitsInOneString) {
-          av.visit(name, BCodeAsmCommon.strEncode(sb))
+          av.visit(name, BCodeAsmCommon.strEncode(sb.sevenBitsMayBeZero))
         } else {
           val arrAnnotV: asm.AnnotationVisitor = av.visitArray(name)
-          for(arg <- BCodeAsmCommon.arrEncode(sb)) { arrAnnotV.visit(name, arg) }
+          for(arg <- BCodeAsmCommon.arrEncode(sb.sevenBitsMayBeZero)) { arrAnnotV.visit(name, arg) }
           arrAnnotV.visitEnd()
         }          // for the lazy val in ScalaSigBytes to be GC'ed, the invoker of emitAnnotations() should hold the ScalaSigBytes in a method-local var that doesn't escape.
 


### PR DESCRIPTION
This abstracts away the necessary parts to be able to get rid of scala.reflect from dotty.