### PR TITLE
Fix exhaustivity check of `classOrArrayType`

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -754,9 +754,7 @@ abstract class BTypes {
     /**
      * Pattern matching on a ClassBType extracts the `internalName` of the class.
      */
-    def unapply(c: ClassBType): Option[String] =
-      if (c == null) None
-      else Some(c.internalName)
+    def unapply(c: ClassBType): Some[String] = Some(c.internalName)
 
     /**
      * Valid flags for InnerClass attribute entry.


### PR DESCRIPTION
Previous the usage of extractor produces an unexhaustive warning. Anyway, the previous code seems problematic to me, as `this` can never be `null`, the check in the extractor is useless.