### PR TITLE
Fix scalac classfile parser crash

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -176,7 +176,7 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
      * can-multi-thread
      */
     def pickleMarkerForeign = {
-      createJAttribute(ScalaSignatureATTRName, new Array[Byte](0), 0, 0)
+      createJAttribute(ScalaATTRName, new Array[Byte](0), 0, 0)
     }
   } // end of trait BCPickles
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
@@ -697,6 +697,7 @@ abstract class BackendInterfaceDefinitions { self: BackendInterface =>
   lazy val LambdaMetaFactory = getClassIfDefined("java.lang.invoke.LambdaMetafactory")
   lazy val MethodHandle = getClassIfDefined("java.lang.invoke.MethodHandle")
 
+  val ScalaATTRName: String = "Scala"
   val ScalaSignatureATTRName: String = "ScalaSig"
   val MetafactoryName: String = "metafactory"
 


### PR DESCRIPTION
As diagnosed by Jason Zaugg, this was caused by `pickleMarkerForeign`
accidentally being changed to emit the attribute "ScalaSig" instead of
"Scala" in 3d66b0dcb23eb352ea7b4d2b82cb9240b7bd3de7