### PR TITLE
Fix IncompatibleClassChangeError under Java 9

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -443,7 +443,7 @@ trait BCodeHelpers extends BCodeIdiomatic with BytecodeWriters {
         "serialVersionUID",
         "J",
         null, // no java-generic-signature
-        new java.lang.Long(id)
+        java.lang.Long.valueOf(id)
       ).visitEnd()
     }
   } // end of trait BCClassGen

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -215,7 +215,8 @@ trait BCodeIdiomatic {
       invokespecial(
         JavaStringBuilderClassName,
         INSTANCE_CONSTRUCTOR_NAME,
-        "()V"
+        "()V",
+        itf = false
       )
     }
 
@@ -398,12 +399,12 @@ trait BCodeIdiomatic {
     final def rem(tk: BType): Unit = { emitPrimitive(JCodeMethodN.remOpcodes, tk) } // can-multi-thread
 
     // can-multi-thread
-    final def invokespecial(owner: String, name: String, desc: String): Unit = {
-      jmethod.visitMethodInsn(Opcodes.INVOKESPECIAL, owner, name, desc, false)
+    final def invokespecial(owner: String, name: String, desc: String, itf: Boolean): Unit = {
+      jmethod.visitMethodInsn(Opcodes.INVOKESPECIAL, owner, name, desc, itf)
     }
     // can-multi-thread
-    final def invokestatic(owner: String, name: String, desc: String): Unit = {
-      jmethod.visitMethodInsn(Opcodes.INVOKESTATIC, owner, name, desc, false)
+    final def invokestatic(owner: String, name: String, desc: String, itf: Boolean): Unit = {
+      jmethod.visitMethodInsn(Opcodes.INVOKESTATIC, owner, name, desc, itf)
     }
     // can-multi-thread
     final def invokeinterface(owner: String, name: String, desc: String): Unit = {
@@ -413,10 +414,6 @@ trait BCodeIdiomatic {
     final def invokevirtual(owner: String, name: String, desc: String): Unit = {
       jmethod.visitMethodInsn(Opcodes.INVOKEVIRTUAL, owner, name, desc, false)
     }
-
-    final def invokedynamic(owner: String, name: String, desc: String): Unit = {
-      jmethod.visitMethodInsn(Opcodes.INVOKEDYNAMIC, owner, name, desc, false)
-     }
 
     // can-multi-thread
     final def goTo(label: asm.Label): Unit = { jmethod.visitJumpInsn(Opcodes.GOTO, label) }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -136,7 +136,7 @@ trait BCodeIdiomatic {
             emit(Opcodes.ICONST_M1)
             emit(Opcodes.IXOR)
           } else if (kind == LONG) {
-            jmethod.visitLdcInsn(new java.lang.Long(-1))
+            jmethod.visitLdcInsn(java.lang.Long.valueOf(-1))
             jmethod.visitInsn(Opcodes.LXOR)
           } else {
             abort(s"Impossible to negate an $kind")
@@ -325,7 +325,7 @@ trait BCodeIdiomatic {
       } else if (cst >= java.lang.Short.MIN_VALUE && cst <= java.lang.Short.MAX_VALUE) {
         jmethod.visitIntInsn(Opcodes.SIPUSH, cst)
       } else {
-        jmethod.visitLdcInsn(new Integer(cst))
+        jmethod.visitLdcInsn(Integer.valueOf(cst))
       }
     }
 
@@ -334,7 +334,7 @@ trait BCodeIdiomatic {
       if (cst == 0L || cst == 1L) {
         emit(Opcodes.LCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Long(cst))
+        jmethod.visitLdcInsn(java.lang.Long.valueOf(cst))
       }
     }
 
@@ -344,7 +344,7 @@ trait BCodeIdiomatic {
       if (bits == 0L || bits == 0x3f800000 || bits == 0x40000000) { // 0..2
         emit(Opcodes.FCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Float(cst))
+        jmethod.visitLdcInsn(java.lang.Float.valueOf(cst))
       }
     }
 
@@ -354,7 +354,7 @@ trait BCodeIdiomatic {
       if (bits == 0L || bits == 0x3ff0000000000000L) { // +0.0d and 1.0d
         emit(Opcodes.DCONST_0 + cst.asInstanceOf[Int])
       } else {
-        jmethod.visitLdcInsn(new java.lang.Double(cst))
+        jmethod.visitLdcInsn(java.lang.Double.valueOf(cst))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendInterface.scala
@@ -440,6 +440,14 @@ abstract class BackendInterface extends BackendInterfaceDefinitions {
     def tpe: Type // todo whats the differentce between tpe and info?
     def thisType: Type
 
+    /** Does this symbol actually correspond to an interface that will be emitted?
+     *  In the backend, this should be preferred over `isInterface` because it
+     *  also returns true for the symbols of the fake companion objects we
+     *  create for Java-defined classes.
+     */
+    final def isEmittedInterface: Boolean = isInterface ||
+      isJavaDefined && isModuleClass && companionClass.isInterface
+
     // tests
     def isClass: Boolean
     def isType: Boolean

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenASM.scala
@@ -1585,7 +1585,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
         if (cst == 0L || cst == 1L) {
           jmethod.visitInsn(Opcodes.LCONST_0 + cst.asInstanceOf[Int])
         } else {
-          jmethod.visitLdcInsn(new java.lang.Long(cst))
+          jmethod.visitLdcInsn(java.lang.Long.valueOf(cst))
         }
       }
 
@@ -2567,7 +2567,7 @@ abstract class GenASM extends SubComponent with BytecodeWriters { self =>
                   emit(Opcodes.ICONST_M1)
                   emit(Opcodes.IXOR)
                 } else if(kind == LONG) {
-                  jmethod.visitLdcInsn(new java.lang.Long(-1))
+                  jmethod.visitLdcInsn(java.lang.Long.valueOf(-1))
                   jmethod.visitInsn(Opcodes.LXOR)
                 } else {
                   abort("Impossible to negate an " + kind)


### PR DESCRIPTION
The itf flag of `visitMethodInsn` and `Handle` in ASM needs to be true
when the method is defined in an interface. Java 8 ignores this but Java
9 fails at runtime with:
java.lang.IncompatibleClassChangeError: Method ... must be InterfaceMethodref constant

This commit is inspired by similar changes in scalac, in particular see
7d51b3fd1569917cb804363bd418466a306f5c89 by Jason Zaugg
(from https://github.com/scala/scala/pull/5251) and
e619b033350a3378d650db4c3e5b1bfc83b73d81 by Lukas Rytz
(from https://github.com/scala/scala/pull/5293). This issue was also
discussed in https://github.com/scala/scala/pull/5452 (which does not
matter for Dotty since we do not run the backend optimizer).