### PR TITLE
Fix compilation of ParMap with ParMapLike

### DIFF
--- a/src/library/scala/collection/parallel/mutable/ParMapLike.scala
+++ b/src/library/scala/collection/parallel/mutable/ParMapLike.scala
@@ -46,7 +46,7 @@ extends scala.collection.GenMapLike[K, V, Repr]
 
   def -=(key: K): this.type
 
-  def +[U >: V](kv: (K, U)) = this.clone().asInstanceOf[ParMap[K, U]] += kv
+  def +[U >: V](kv: (K, U)): ParMap[K, U] = this.clone().asInstanceOf[ParMap[K, U]] += kv
 
   def -(key: K) = this.clone() -= key
 


### PR DESCRIPTION
When compiled with Dotty, the result type of mutable.ParMapLike#+ comes from an
overriden trait instead of being inferred from the rhs. This prevents
mutable.ParMap from compiling since it relies on this more precise
result type.