### PR TITLE
Teach genLoadIf that a `()` else branch is the same as no else branch.

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -202,7 +202,10 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
       val success = new asm.Label
       val failure = new asm.Label
 
-      val hasElse = !elsep.isEmpty
+      val hasElse = !elsep.isEmpty && (elsep match {
+        case Literal(value) if value.tag == UnitTag => false
+	case _ => true
+      })
       val postIf  = if (hasElse) new asm.Label else failure
 
       genCond(condp, success, failure, targetIfNoJump = success)


### PR DESCRIPTION
This avoids generating dead code gotos.